### PR TITLE
name mismatch when setting link model (fixes point queue)

### DIFF
--- a/src/main/java/common/Network.java
+++ b/src/main/java/common/Network.java
@@ -220,7 +220,7 @@ public class Network {
                                         jaxb_model.getModelParams().getSimDt(),
                                         jaxb_model.getModelParams().getMaxCellLength());
                     break;
-                case "pq":
+                case "point_queue":
                     model = new Model_PQ(jaxb_model.getName(),jaxb_model.isIsDefault());
                     break;
                 default:


### PR DESCRIPTION
CTM works fine, but I'm getting the following error when using point queue:
```
Exception in thread "main" java.lang.NullPointerException
        at plugin.PluginLoader.get_controller_instance(PluginLoader.java:56)
        at runner.ScenarioFactory.create_controllers_from_jaxb(ScenarioFactory.java:309)
        at runner.ScenarioFactory.create_scenario(ScenarioFactory.java:60)
        at api.API.load(API.java:68)
        at runner.OTM.load(OTM.java:159)
        at runner.OTM.main(OTM.java:114)
```
This change catches the correct model type for point queue and assigns the link model correctly. It might also be better to default to an error if there's no valid case where a link model is missing.