### PR TITLE
allow traffic on signal off, null command

### DIFF
--- a/src/main/java/actuator/sigint/ActuatorSignal.java
+++ b/src/main/java/actuator/sigint/ActuatorSignal.java
@@ -88,48 +88,54 @@ public class ActuatorSignal extends AbstractActuator {
     @Override
     public void process_controller_command(Object command, Dispatcher dispatcher, float timestamp) throws OTMException {
 
-         current_scehdule_item = (ScheduleItem) command;
-         float cycle_time = current_scehdule_item.get_cycle_time(timestamp);
+        if (command != null){
+            current_scehdule_item = (ScheduleItem) command;
+            float cycle_time = current_scehdule_item.get_cycle_time(timestamp);
 
-         // remove future phase transition events from the dispatcher
-         for(SignalPhase phase : signal_phases.values())
-             dispatcher.remove_events_for_recipient(EventAdvanceSignalPhase.class,phase);
+            // remove future phase transition events from the dispatcher
+            for(SignalPhase phase : signal_phases.values())
+                dispatcher.remove_events_for_recipient(EventAdvanceSignalPhase.class,phase);
 
-         // clear phase transitions
-         signal_phases.values().forEach(x->x.transitions.clear());
+            // clear phase transitions
+            signal_phases.values().forEach(x->x.transitions.clear());
 
-         // generate new green/red transitions
-         for(Stage stage:current_scehdule_item.stages.queue){
-             float r2g = stage.cycle_starttime;
-             float g2r = (r2g + stage.duration) % current_scehdule_item.cycle;
-             for(long phase_id : stage.phase_ids){
-                 SignalPhase phase = signal_phases.get(phase_id);
-                 phase.transitions.add(new PhaseTransition(r2g,BulbColor.RED,BulbColor.GREEN));
-                 phase.transitions.add(new PhaseTransition(g2r,BulbColor.GREEN,BulbColor.RED));
-             }
-         }
+            // generate new green/red transitions
+            for(Stage stage:current_scehdule_item.stages.queue){
+                float r2g = stage.cycle_starttime;
+                float g2r = (r2g + stage.duration) % current_scehdule_item.cycle;
+                for(long phase_id : stage.phase_ids){
+                    SignalPhase phase = signal_phases.get(phase_id);
+                    phase.transitions.add(new PhaseTransition(r2g,BulbColor.RED,BulbColor.GREEN));
+                    phase.transitions.add(new PhaseTransition(g2r,BulbColor.GREEN,BulbColor.RED));
+                }
+            }
 
-         for(SignalPhase phase : signal_phases.values()) {
+            for(SignalPhase phase : signal_phases.values()) {
 
-             if(phase.transitions.queue.isEmpty())
-                 continue;
+                if(phase.transitions.queue.isEmpty())
+                    continue;
 
-             phase.cancel_redundate_transitions();
-             phase.insert_yellow_time();
+                phase.cancel_redundate_transitions();
+                phase.insert_yellow_time();
 
-             // set state for current time ............
-             PhaseTransition recent_transition = phase.get_transition_preceding(cycle_time);
-             phase.transitions.point_to(recent_transition);
-             phase.set_bulb_color(timestamp,recent_transition.to_color);
+                // set state for current time ............
+                PhaseTransition recent_transition = phase.get_transition_preceding(cycle_time);
+                phase.transitions.point_to(recent_transition);
+                phase.set_bulb_color(timestamp,recent_transition.to_color);
 
-             // special case: next transition is now
-             if(phase.transitions.peek_next().cycle_time==cycle_time)
-                 phase.advance_transitions(timestamp);
+                // special case: next transition is now
+                if(phase.transitions.peek_next().cycle_time==cycle_time)
+                    phase.advance_transitions(timestamp);
 
-             // execute next transition
-             phase.register_next_transtions(dispatcher,timestamp,cycle_time);
+                // execute next transition
+                phase.register_next_transtions(dispatcher,timestamp,cycle_time);
 
-         }
+            }
+        } else {
+            // null command triggers turning off the signal,
+            // i.e. allow traffic to pass for all phases.
+            turn_off(timestamp);
+        }
 
      }
 

--- a/src/main/java/actuator/sigint/SignalPhase.java
+++ b/src/main/java/actuator/sigint/SignalPhase.java
@@ -125,7 +125,8 @@ public class SignalPhase {
     }
 
     public void turn_off(float timestamp) throws OTMException {
-        set_bulb_color(timestamp, BulbColor.DARK);
+        for(RoadConnection rc : road_connections)
+            rc.set_external_max_flow_vps(timestamp, Float.POSITIVE_INFINITY);
     }
 
     ///////////////////////////////////////////////////


### PR DESCRIPTION
Previously, turning off the signal sets the phases to `BulbColor.DARK` which then sets vehicle flow for all road connections to 0, effectively blocking the whole intersection. This PR changes `SignalPhase.turn_off` to behave as if all phases are set to green, allowing traffic on all directions.  This also adds a null controller command for `ActuatorSignal` which allows custom controllers to turn off the signal during simulation. 