### PR TITLE
Implement simple signal actuators (e.g. for max pressure)

### DIFF
--- a/src/main/java/actuator/AbstractActuator.java
+++ b/src/main/java/actuator/AbstractActuator.java
@@ -22,6 +22,7 @@ public abstract class AbstractActuator implements InterfacePokable, InterfaceSce
 
     public enum Type {
         signal,
+        signal_simple,
         stop,
         ramp_meter,
         fd,

--- a/src/main/java/actuator/sigint/ActuatorSignalSimple.java
+++ b/src/main/java/actuator/sigint/ActuatorSignalSimple.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2018, Gabriel Gomes
+ * All rights reserved.
+ * This source code is licensed under the standard 3-clause BSD license found
+ * in the LICENSE file in the root directory of this source tree.
+ */
+package actuator.sigint;
+
+import actuator.AbstractActuator;
+import control.sigint.ScheduleItem;
+import dispatch.Dispatcher;
+import error.OTMErrorLog;
+import error.OTMException;
+import runner.Scenario;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ActuatorSignalSimple extends AbstractActuator {
+
+    public Map<Long, SignalPhaseSimple> signal_phases;
+    public ScheduleItem current_schedule_item;
+
+    ///////////////////////////////////////////////////
+    // construction
+    ///////////////////////////////////////////////////
+
+    public ActuatorSignalSimple(Scenario scenario, jaxb.Actuator jaxb_actuator) throws OTMException {
+        super(scenario,jaxb_actuator);
+
+        // must be on a node
+        if(target==null || !(target instanceof common.Node))
+            return;
+
+        if(jaxb_actuator.getSignal()==null)
+            return;
+
+        signal_phases = new HashMap<>();
+        for(jaxb.Phase jaxb_phase : jaxb_actuator.getSignal().getPhase())
+            signal_phases.put(jaxb_phase.getId(), new SignalPhaseSimple(scenario, this, jaxb_phase));
+
+    }
+
+    @Override
+    public void validate(OTMErrorLog errorLog) {
+        super.validate(errorLog);
+
+        if(signal_phases==null)
+            errorLog.addError("ActuatorSignalSimple ID=" + id + " contains no valid phases.");
+        else
+            for(SignalPhaseSimple p : signal_phases.values())
+                p.validate(errorLog);
+    }
+
+    @Override
+    public void initialize(Scenario scenario) throws OTMException {
+        float now = scenario.get_current_time();
+        // set all bulb colors to dark
+        for(SignalPhaseSimple p : signal_phases.values() )
+            p.initialize(now);
+    }
+
+    @Override
+    public void poke(Dispatcher dispatcher, float timestamp) throws OTMException {
+        super.poke(dispatcher, timestamp);
+    }
+
+    public void turn_off(float now) throws OTMException {
+        for(SignalPhaseSimple p : signal_phases.values() )
+            p.turn_off(now);
+    }
+
+    public SignalPhaseSimple get_phase(long phase_id){
+        return signal_phases.get(phase_id);
+    }
+
+    public void enable_phase(long phase_id, float time) throws OTMException {
+        if (!signal_phases.keySet().contains(phase_id)){
+            throw new OTMException(
+                String.format("phase ID %s is not in actuator %s", phase_id, id));
+        } else {
+            signal_phases.values().forEach(p -> p.disable(time));
+            signal_phases.values().stream().filter(p -> p.id == phase_id).forEach(p -> p.enable(time));
+        }        
+    }
+
+    ///////////////////////////////////////////////////
+    // control
+    ///////////////////////////////////////////////////
+
+    @Override
+    public void process_controller_command(Object command, Dispatcher dispatcher, float timestamp) throws OTMException {
+
+        if (command != null){
+            enable_phase((long) command, timestamp);
+        } else {
+            // null command triggers turning off the signal,
+            // i.e. allow traffic to pass for all phases.
+            turn_off(timestamp);
+        }
+
+     }
+
+}

--- a/src/main/java/actuator/sigint/SignalPhaseSimple.java
+++ b/src/main/java/actuator/sigint/SignalPhaseSimple.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2018, Gabriel Gomes
+ * All rights reserved.
+ * This source code is licensed under the standard 3-clause BSD license found
+ * in the LICENSE file in the root directory of this source tree.
+ */
+package actuator.sigint;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import actuator.AbstractActuator;
+import common.RoadConnection;
+import error.OTMErrorLog;
+import error.OTMException;
+import runner.ScenarioElementType;
+import runner.Scenario;
+import utils.OTMUtils;
+
+
+public class SignalPhaseSimple {
+    public long id;
+    public ActuatorSignalSimple my_signal;
+    public Set<RoadConnection> road_connections;
+    public float signalFlowRate;
+
+    public SignalPhaseSimple(Scenario scenario, AbstractActuator actuator, jaxb.Phase jaxb_phase) throws OTMException {
+        this.id = jaxb_phase.getId();
+        this.my_signal = (ActuatorSignalSimple) actuator;
+        this.signalFlowRate = Float.POSITIVE_INFINITY;
+
+        road_connections = new HashSet<>();
+        for(Long id : OTMUtils.csv2longlist(jaxb_phase.getRoadconnectionIds())) {
+            RoadConnection rc = (RoadConnection) scenario.get_element(ScenarioElementType.roadconnection, id);
+            if(rc==null)
+                throw new OTMException("bad road connection id in actuator id=" + this.id);
+            road_connections.add(rc);
+        }
+    }
+
+    public void validate(OTMErrorLog errorLog) {}
+
+    public void initialize(float time) throws OTMException {}
+
+    private void set_rc_maxflow(float time, float rate) {        
+        road_connections.forEach(rc -> rc.set_external_max_flow_vps(time, rate));
+    }
+
+    public void disable(float time) {
+        // DISABLE => disable flow (e.g. waiting for other phases to finish)
+        set_rc_maxflow(time, 0.0f);
+    }
+
+    public void enable(float time) {
+        // ENABLE => enable flow based on intersection flow rate
+        set_rc_maxflow(time, signalFlowRate);
+    }
+
+    public void turn_off(float time) {
+        // Turn OFF => Disable signal (ignore intersection effect)
+        set_rc_maxflow(time, Float.POSITIVE_INFINITY);
+    }
+
+}

--- a/src/main/java/models/pq/LaneGroup.java
+++ b/src/main/java/models/pq/LaneGroup.java
@@ -144,7 +144,10 @@ public class LaneGroup extends AbstractLaneGroupVehicles {
                 saturation_flow_rate_vps :
                 current_max_flow_rate_vps;
 
-        // TODO: REMOVE FUTURE RELEASES?
+        // Remove scheduled future releases from the previous RC capacity,
+        // will be replaced by new schedule with modified capacity.
+        link.network.scenario.dispatcher
+                .remove_events_for_recipient(EventReleaseVehicleFromLaneGroup.class, this);
 
         // schedule a release for now+ half wait time
         schedule_release_vehicle(timestamp,current_max_flow_rate_vps*2);

--- a/src/main/java/models/pq/LaneGroup.java
+++ b/src/main/java/models/pq/LaneGroup.java
@@ -119,7 +119,8 @@ public class LaneGroup extends AbstractLaneGroupVehicles {
             veh.move_to_queue(timestamp,transit_queue);
 
             // tell the travel timers
-            ((VehicleLaneGroupTimer)travel_timer).vehicle_enter(timestamp,veh);
+            if (travel_timer != null)
+                ((VehicleLaneGroupTimer)travel_timer).vehicle_enter(timestamp,veh);
 
             // register_with_dispatcher dispatch to go to waiting queue
             dispatcher.register_event(new EventTransitToWaiting(dispatcher,timestamp + transit_time_sec,veh));
@@ -191,7 +192,8 @@ public class LaneGroup extends AbstractLaneGroupVehicles {
                     ev.move_from_to_queue(timestamp,vehicle,waiting_queue,null);
 
             // inform the travel timers
-            ((VehicleLaneGroupTimer)travel_timer).vehicle_exit(timestamp,vehicle,link.getId(),null);
+            if (travel_timer != null)
+                ((VehicleLaneGroupTimer)travel_timer).vehicle_exit(timestamp,vehicle,link.getId(),null);
 
         }
         else{
@@ -228,7 +230,8 @@ public class LaneGroup extends AbstractLaneGroupVehicles {
                 waiting_queue.remove_given_vehicle(timestamp,vehicle);
 
                 // inform the travel timers
-                ((VehicleLaneGroupTimer)travel_timer).vehicle_exit(timestamp,vehicle,link.getId(),next_link);
+                if (travel_timer != null)
+                    ((VehicleLaneGroupTimer)travel_timer).vehicle_exit(timestamp,vehicle,link.getId(),next_link);
 
                 // send vehicle packet to next link
                 next_link.model.add_vehicle_packet(next_link,timestamp,new PacketLink(vehicle,rc));

--- a/src/main/java/runner/ScenarioFactory.java
+++ b/src/main/java/runner/ScenarioFactory.java
@@ -8,6 +8,7 @@ package runner;
 
 import actuator.*;
 import actuator.sigint.ActuatorSignal;
+import actuator.sigint.ActuatorSignalSimple;
 import commodity.*;
 import commodity.Commodity;
 import commodity.Subnetwork;
@@ -200,6 +201,9 @@ public class ScenarioFactory {
             switch(jaxb_actuator.getType()){
                 case "signal":
                     actuator = new ActuatorSignal(scenario,jaxb_actuator);
+                    break;
+                case "signal_simple":
+                    actuator = new ActuatorSignalSimple(scenario,jaxb_actuator);
                     break;
                 case "stop":
                     actuator = new ActuatorStop(scenario,jaxb_actuator);


### PR DESCRIPTION
The PR implements an additional actuator implementation `ActuatorSignalSimple` which, instead of maintaining a fixed signal schedule, relies on polling the controller which phase should permit flow. The corresponding signals for the actuator uses `SignalPhaseSimple` where instead of red/green times, can only be enabled or disabled by the actuator by changing the road connection flow rate. This will allow for implementing custom algorithms such as max-pressure where the backpressure value is computed in the controller side.

The design of `ActuatorSignalSimple` and `SignalPhaseSimple` allows for using the same XML schema as that of `ActuatorSignal` and `SignalPhase`. With some modifications, these can also be used as their respective subclasses.

The new signal actuator implementation currently relies on the unused `signal_simple` actuator type name (see [ggomes/otm-base - otm.xsd:L472](https://github.com/ggomes/otm-base/blob/f83886b0e9e85cb84ae9bb228481f69c11cef6d8/src/main/resources/otm.xsd#L472)); this can be renamed, but needs changes on the otm-base side.

In addition, this PR adds two bug fixes which allows for implementing the actuators:

1. Delete scheduled future releases whenever a new max-flow is set for a road connection which by itself creates new scheduled events. Setting the flow on RCs multiple times creates stale events on dispatcher which never get removed from the queue, thus significantly slowing down the simulation, esp. when the actuator relies on changing RC flow several times.

2. Add travel time measurements in point-queue model lane groups only when requested, fixing PQ simulations without travel time request for the recent commits.